### PR TITLE
15 update cart 카트 수정

### DIFF
--- a/order-api/scratch_oder.http
+++ b/order-api/scratch_oder.http
@@ -101,3 +101,31 @@ X-AUTH-TOKEN:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6aEJHaWtEb2hZZDRob0syZVhZb0tIV0U1dD
 GET http://localhost:8082/customer/cart
 Content-Type: application/json
 X-AUTH-TOKEN:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6aEJHaWtEb2hZZDRob0syZVhZb0tIV0U1dDg5SHlpL1RyL1UyUmRtZGZFPSIsImp0aSI6IlN1YkhlS1VSUnJlUVkrV1NPbkJrdGc9PSIsInJvbGVzIjoiU0VMTEVSIiwiaWF0IjoxNjkyMTE1MTYxLCJleHAiOjE2OTIyMDE1NjF9.SRy2h6flH9addf5FQzlxrodPECQBD6kMwaSxHNqSf1E
+
+### 카트 수정
+PUT http://localhost:8082/customer/cart
+Content-Type: application/json
+X-AUTH-TOKEN:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6aEJHaWtEb2hZZDRob0syZVhZb0tIV0U1dDg5SHlpL1RyL1UyUmRtZGZFPSIsImp0aSI6IlN1YkhlS1VSUnJlUVkrV1NPbkJrdGc9PSIsInJvbGVzIjoiU0VMTEVSIiwiaWF0IjoxNjkyMTE1MTYxLCJleHAiOjE2OTIyMDE1NjF9.SRy2h6flH9addf5FQzlxrodPECQBD6kMwaSxHNqSf1E
+
+{
+  "customerId": 1,
+  "messages": [
+    "수량이 변경되었습니다."
+  ],
+  "products": [
+    {
+      "description": "상품 설명",
+      "id": 1,
+      "items": [
+        {
+          "count": 0,
+          "id": 1,
+          "name": "270",
+          "price": 100000
+        }
+      ],
+      "name": "나이키 에어포스",
+      "sellerId": 1
+    }
+  ]
+}

--- a/order-api/src/main/java/com/zerobase/cms/order/application/CartApplication.java
+++ b/order-api/src/main/java/com/zerobase/cms/order/application/CartApplication.java
@@ -37,6 +37,11 @@ public class CartApplication {
         return cartService.addCart(customerId, form);
     }
 
+    public Cart updateCart(Long customerId, Cart cart) {
+        cartService.putCart(customerId, cart);
+        return getCart(customerId);
+    }
+
     public Cart getCart(Long customerId) {
         Cart cart = refreshCart(cartService.getCart(customerId));
         Cart returnCart = new Cart();

--- a/order-api/src/main/java/com/zerobase/cms/order/controller/CustomerCartController.java
+++ b/order-api/src/main/java/com/zerobase/cms/order/controller/CustomerCartController.java
@@ -27,4 +27,11 @@ public class CustomerCartController {
         return ResponseEntity.ok(cartApplication.
                 getCart(provider.getUserVo(token).getId()));
     }
+
+    @PutMapping
+    public ResponseEntity<Cart> updateCart(@RequestHeader(name = "X-AUTH-TOKEN") String token,
+                                           @RequestBody Cart cart) {
+        return ResponseEntity.ok(cartApplication.updateCart(
+                        provider.getUserVo(token).getId(), cart));
+    }
 }


### PR DESCRIPTION
Changes
---

카트 조회 로직을 재사용하여 코드 생산성 향상
기존 카트 조회 로직의 가격과 수량, 상품의 삭제 등을 체크하는 로직이 이미 존재해, 이를 호출하여 에러 메세지와 카트의 내용을 업데이트 하는 것으로 적용
